### PR TITLE
Imp: do not use read/write queue

### DIFF
--- a/getty.go
+++ b/getty.go
@@ -153,8 +153,6 @@ type Session interface {
 	SetReader(Reader)
 	SetWriter(Writer)
 	SetCronPeriod(int)
-	SetRQLen(int)
-	SetWQLen(int)
 	SetWaitTime(time.Duration)
 	SetTaskPool(*TaskPool)
 

--- a/task_pool.go
+++ b/task_pool.go
@@ -11,10 +11,7 @@ const (
 )
 
 // task t
-type task struct {
-	session *session
-	pkg     interface{}
-}
+type task func()
 
 // task pool: manage task ts
 type TaskPool struct {
@@ -83,7 +80,7 @@ func (p *TaskPool) run(id int, q chan task) {
 
 		case t, ok = <-q:
 			if ok {
-				t.session.listener.OnMessage(t.session, t.pkg)
+				t()
 			}
 		}
 	}


### PR DESCRIPTION
two improvements:
1 delete read queue to handle OnMessage in handleTcpPackage or in task pool;
2 delete write queue to write package in OnMessage;