### PR TITLE
Fix: do not invoke s.incWritePkgNum in handleLoop

### DIFF
--- a/session.go
+++ b/session.go
@@ -552,7 +552,6 @@ LOOP:
 					flag = false
 					// break LOOP
 				}
-				s.incWritePkgNum()
 			} else {
 				log.Infof("[session.handleLoop] drop writeout package{%#v}", outPkg)
 			}


### PR DESCRIPTION
do not invoke s.incWritePkgNum in handleLoop because WriteBytes will invoke it