### PR TITLE
Fix issue29: skip the log output of EOF error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,4 @@ classes
 # vim
 *.swp
 
-# go.sum
-# Gopkg.lock
-# vendor/
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ go:
   - "1.12"
   - "1.13"
 
+env:
+  - GO111MODULE=on
+
 script:
   - go fmt ./... && [[ -z `git status -s` ]]
-  - GO111MODULE=on && go mod vendor && go test ./... -bench . -race -v
-
+  - go mod vendor && go test ./... -bench . -race -v


### PR DESCRIPTION
Fix https://github.com/dubbogo/getty/issues/29.