### PR TITLE
Opt: split large packet to n*16KB packet

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -167,7 +167,7 @@ func TestTCPClient(t *testing.T) {
 	assert.Equal(t, beforeWriteBytes, conn.writeBytes)
 	assert.True(t, conn.compress == CompressSnappy)
 
-	batchSize := 30000000
+	batchSize := 128 * 1023
 	source := make([]byte, batchSize)
 	for i := 0; i < batchSize; i++ {
 		source[i] = 't'
@@ -177,6 +177,19 @@ func TestTCPClient(t *testing.T) {
 	assert.True(t, l == batchSize)
 	beforeWriteBytes.Add(uint32(batchSize))
 	beforeWritePkgNum.Add(uint32(batchSize/16/1024) + 1)
+	assert.Equal(t, beforeWriteBytes, conn.writeBytes)
+	assert.Equal(t, beforeWritePkgNum, conn.writePkgNum)
+
+	batchSize = 32 * 1024
+	source = make([]byte, batchSize)
+	for i := 0; i < batchSize; i++ {
+		source[i] = 't'
+	}
+	l, err = ss.WriteBytes(source)
+	assert.Nil(t, err)
+	assert.True(t, l == batchSize)
+	beforeWriteBytes.Add(uint32(batchSize))
+	beforeWritePkgNum.Add(2)
 	assert.Equal(t, beforeWriteBytes, conn.writeBytes)
 	assert.Equal(t, beforeWritePkgNum, conn.writePkgNum)
 

--- a/client_test.go
+++ b/client_test.go
@@ -167,6 +167,19 @@ func TestTCPClient(t *testing.T) {
 	assert.Equal(t, beforeWriteBytes, conn.writeBytes)
 	assert.True(t, conn.compress == CompressSnappy)
 
+	batchSize := 30000000
+	source := make([]byte, batchSize)
+	for i := 0; i < batchSize; i++ {
+		source[i] = 't'
+	}
+	l, err = ss.WriteBytes(source)
+	assert.Nil(t, err)
+	assert.True(t, l == batchSize)
+	beforeWriteBytes.Add(uint32(batchSize))
+	beforeWritePkgNum.Add(uint32(batchSize/16/1024) + 1)
+	assert.Equal(t, beforeWriteBytes, conn.writeBytes)
+	assert.Equal(t, beforeWritePkgNum, conn.writePkgNum)
+
 	clt.Close()
 	assert.True(t, clt.IsClosed())
 }

--- a/session.go
+++ b/session.go
@@ -422,11 +422,7 @@ func (s *session) WriteBytes(pkg []byte) (int, error) {
 		return 0, ErrSessionClosed
 	}
 
-	totalSize := len(pkg)
-	if totalSize == 0 {
-		return 0, nil
-	}
-	writeSize := 0
+	totalSize, writeSize := len(pkg), 0
 	s.wlock.Lock()
 	defer s.wlock.Unlock()
 	for totalSize >= maxPacketLen {
@@ -437,6 +433,11 @@ func (s *session) WriteBytes(pkg []byte) (int, error) {
 		totalSize -= maxPacketLen
 		writeSize += maxPacketLen
 	}
+
+	if totalSize == 0 {
+		return writeSize, nil
+	}
+
 	lg, err := s.Connection.send(pkg[writeSize:])
 	if err != nil {
 		return writeSize, perrors.Wrapf(err, "s.Connection.Write(pkg len:%d)", len(pkg))

--- a/session.go
+++ b/session.go
@@ -402,6 +402,8 @@ func (s *session) WritePkg(pkg interface{}, timeout time.Duration) (int, int, er
 	} else {
 		pkg = pkgBytes
 	}
+	s.wlock.Lock()
+	defer s.wlock.Unlock()
 	if 0 < timeout {
 		s.Connection.SetWriteTimeout(timeout)
 	}
@@ -450,6 +452,8 @@ func (s *session) WriteBytesArray(pkgs ...[]byte) (int, error) {
 
 	// reduce syscall and memcopy for multiple packages
 	if _, ok := s.Connection.(*gettyTCPConn); ok {
+		s.wlock.Lock()
+		defer s.wlock.Unlock()
 		lg, err := s.Connection.send(pkgs)
 		if err != nil {
 			return 0, perrors.Wrapf(err, "s.Connection.Write(pkgs num:%d)", len(pkgs))

--- a/session.go
+++ b/session.go
@@ -423,7 +423,7 @@ func (s *session) WriteBytes(pkg []byte) (int, error) {
 	}
 
 	leftPackageSize, totalSize, writeSize := len(pkg), len(pkg), 0
-	if leftPackageSize >= maxPacketLen {
+	if leftPackageSize > maxPacketLen {
 		s.packetLock.Lock()
 		defer s.packetLock.Unlock()
 	} else {
@@ -431,7 +431,7 @@ func (s *session) WriteBytes(pkg []byte) (int, error) {
 		defer s.packetLock.RUnlock()
 	}
 
-	for leftPackageSize >= maxPacketLen {
+	for leftPackageSize > maxPacketLen {
 		_, err := s.Connection.send(pkg[writeSize:(writeSize + maxPacketLen)])
 		if err != nil {
 			return writeSize, perrors.Wrapf(err, "s.Connection.Write(pkg len:%d)", len(pkg))

--- a/session.go
+++ b/session.go
@@ -128,8 +128,8 @@ type session struct {
 	attrs *gxcontext.ValuesContext
 
 	// goroutines sync
-	grNum uatomic.Int32
-	lock  sync.RWMutex
+	grNum      uatomic.Int32
+	lock       sync.RWMutex
 	packetLock sync.RWMutex
 }
 

--- a/session.go
+++ b/session.go
@@ -47,7 +47,7 @@ const (
 	pendingDuration = 3e9
 	// MaxWheelTimeSpan 900s, 15 minute
 	MaxWheelTimeSpan = 900e9
-	maxPacketLen = 16*1024
+	maxPacketLen     = 16 * 1024
 
 	defaultSessionName    = "session"
 	defaultTCPSessionName = "tcp-session"
@@ -422,7 +422,7 @@ func (s *session) WriteBytes(pkg []byte) (int, error) {
 	totalSize := len(pkg)
 	writeSize := 0
 	for totalSize >= maxPacketLen {
-		lg, err := s.Connection.send(pkg[writeSize:(writeSize+maxPacketLen)])
+		lg, err := s.Connection.send(pkg[writeSize:(writeSize + maxPacketLen)])
 		if err != nil {
 			return writeSize, perrors.Wrapf(err, "s.Connection.Write(pkg len:%d)", len(pkg))
 		}
@@ -432,10 +432,10 @@ func (s *session) WriteBytes(pkg []byte) (int, error) {
 
 	lg, err := s.Connection.send(pkg[writeSize:])
 	if err != nil {
-		return writeSize+lg, perrors.Wrapf(err, "s.Connection.Write(pkg len:%d)", len(pkg))
+		return writeSize + lg, perrors.Wrapf(err, "s.Connection.Write(pkg len:%d)", len(pkg))
 	}
 
-	return writeSize+lg, nil
+	return writeSize + lg, nil
 }
 
 // WriteBytesArray Write multiple packages at once. so we invoke write sys.call just one time.

--- a/session.go
+++ b/session.go
@@ -422,9 +422,13 @@ func (s *session) WriteBytes(pkg []byte) (int, error) {
 		return 0, ErrSessionClosed
 	}
 
+	totalSize := len(pkg)
+	if totalSize == 0 {
+		return 0, nil
+	}
+	writeSize := 0
 	s.wlock.Lock()
 	defer s.wlock.Unlock()
-	totalSize, writeSize := len(pkg), 0
 	for totalSize >= maxPacketLen {
 		_, err := s.Connection.send(pkg[writeSize:(writeSize + maxPacketLen)])
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
split large packet to 16KB packet and send one by one for reduce risk when send large packet.
recv will compact small packet in a large one.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```