### PR TITLE
Fix: taskPool will execute task when session was nil

### DIFF
--- a/session.go
+++ b/session.go
@@ -565,6 +565,11 @@ func (s *session) run() {
 
 func (s *session) addTask(pkg interface{}) {
 	f := func() {
+		s.lock.RLock()
+		defer s.lock.RUnlock()
+		if s.Connection == nil {
+			return
+		}
 		s.listener.OnMessage(s, pkg)
 		s.incReadPkgNum()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
First task was be added into task pool, then session will be set to nil with connection interrupted and task was executed by goroutine will lead to panic.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #88

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```