### PR TITLE
refactor: Supports mock testing of the getty.Session interface outside of the getty package.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -134,7 +134,7 @@ func TestTCPClient(t *testing.T) {
 	assert.True(t, conn.compress == CompressNone)
 	beforeWriteBytes := conn.writeBytes
 	beforeWritePkgNum := conn.writePkgNum
-	l, err := conn.send([]byte("hello"))
+	l, err := conn.Send([]byte("hello"))
 	assert.Nil(t, err)
 	assert.True(t, l == 5)
 	beforeWritePkgNum.Add(1)
@@ -150,7 +150,7 @@ func TestTCPClient(t *testing.T) {
 	assert.Equal(t, beforeWritePkgNum, conn.writePkgNum)
 	var pkgs [][]byte
 	pkgs = append(pkgs, []byte("hello"), []byte("hello"))
-	l, err = conn.send(pkgs)
+	l, err = conn.Send(pkgs)
 	assert.Nil(t, err)
 	assert.True(t, l == 10)
 	beforeWritePkgNum.Add(2)
@@ -264,11 +264,11 @@ func TestUDPClient(t *testing.T) {
 	}
 	t.Logf("udp context:%s", udpCtx)
 	udpConn := ss.(*session).Connection.(*gettyUDPConn)
-	_, err = udpConn.send(udpCtx)
+	_, err = udpConn.Send(udpCtx)
 	assert.NotNil(t, err)
 	udpCtx.Pkg = []byte("hello")
 	beforeWriteBytes := udpConn.writeBytes
-	_, err = udpConn.send(udpCtx)
+	_, err = udpConn.Send(udpCtx)
 	beforeWriteBytes.Add(5)
 	assert.Equal(t, beforeWriteBytes, udpConn.writeBytes)
 	assert.Nil(t, err)
@@ -327,11 +327,11 @@ func TestNewWSClient(t *testing.T) {
 	assert.True(t, conn.compress == CompressNone)
 	err := conn.handlePing("hello")
 	assert.Nil(t, err)
-	l, err := conn.send("hello")
+	l, err := conn.Send("hello")
 	assert.NotNil(t, err)
 	assert.True(t, l == 0)
 	beforeWriteBytes := conn.writeBytes
-	_, err = conn.send([]byte("hello"))
+	_, err = conn.Send([]byte("hello"))
 	assert.Nil(t, err)
 	beforeWriteBytes.Add(5)
 	assert.Equal(t, beforeWriteBytes, conn.writeBytes)

--- a/connection.go
+++ b/connection.go
@@ -45,23 +45,27 @@ type Connection interface {
 	SetCompressType(CompressType)
 	LocalAddr() string
 	RemoteAddr() string
+	// IncReadPkgNum increases connection's read pkg number
 	IncReadPkgNum()
+	// IncWritePkgNum increases connection's write pkg number
 	IncWritePkgNum()
 	// UpdateActive update session's active time
 	UpdateActive()
 	// GetActive get session's active time
 	GetActive() time.Time
+	// ReadTimeout gets deadline for the future read calls.
 	ReadTimeout() time.Duration
 	// SetReadTimeout sets deadline for the future read calls.
 	SetReadTimeout(time.Duration)
+	// WriteTimeout gets deadline for the future write calls.
 	WriteTimeout() time.Duration
-	// SetWriteTimeout sets deadline for the future read calls.
+	// SetWriteTimeout sets deadline for the future write calls.
 	SetWriteTimeout(time.Duration)
+	// Send pkg data to peer
 	Send(interface{}) (int, error)
-	// don't distinguish between tcp connection and websocket connection. Because
-	// gorilla/websocket/conn.go:(Conn)Close also invoke net.Conn.Close
+	// CloseConn close connection
 	CloseConn(int)
-	// set related session
+	// SetSession sets related session
 	SetSession(Session)
 }
 

--- a/session.go
+++ b/session.go
@@ -147,7 +147,7 @@ func newSession(endPoint EndPoint, conn Connection) *session {
 		attrs: gxcontext.NewValuesContext(context.Background()),
 	}
 
-	ss.Connection.setSession(ss)
+	ss.Connection.SetSession(ss)
 	ss.SetWriteTimeout(netIOTimeout)
 	ss.SetReadTimeout(netIOTimeout)
 
@@ -405,7 +405,7 @@ func (s *session) WritePkg(pkg interface{}, timeout time.Duration) (int, int, er
 		s.Connection.SetWriteTimeout(timeout)
 	}
 	var succssCount int
-	succssCount, err = s.Connection.send(pkg)
+	succssCount, err = s.Connection.Send(pkg)
 	if err != nil {
 		log.Warnf("%s, [session.WritePkg] @s.Connection.Write(pkg:%#v) = err:%+v", s.Stat(), pkg, err)
 		return len(pkgBytes), succssCount, perrors.WithStack(err)
@@ -429,7 +429,7 @@ func (s *session) WriteBytes(pkg []byte) (int, error) {
 	}
 
 	for leftPackageSize > maxPacketLen {
-		_, err := s.Connection.send(pkg[writeSize:(writeSize + maxPacketLen)])
+		_, err := s.Connection.Send(pkg[writeSize:(writeSize + maxPacketLen)])
 		if err != nil {
 			return writeSize, perrors.Wrapf(err, "s.Connection.Write(pkg len:%d)", len(pkg))
 		}
@@ -441,7 +441,7 @@ func (s *session) WriteBytes(pkg []byte) (int, error) {
 		return writeSize, nil
 	}
 
-	_, err := s.Connection.send(pkg[writeSize:])
+	_, err := s.Connection.Send(pkg[writeSize:])
 	if err != nil {
 		return writeSize, perrors.Wrapf(err, "s.Connection.Write(pkg len:%d)", len(pkg))
 	}
@@ -462,7 +462,7 @@ func (s *session) WriteBytesArray(pkgs ...[]byte) (int, error) {
 	if _, ok := s.Connection.(*gettyTCPConn); ok {
 		s.packetLock.RLock()
 		defer s.packetLock.RUnlock()
-		lg, err := s.Connection.send(pkgs)
+		lg, err := s.Connection.Send(pkgs)
 		if err != nil {
 			return 0, perrors.Wrapf(err, "s.Connection.Write(pkgs num:%d)", len(pkgs))
 		}
@@ -501,7 +501,7 @@ func (s *session) WriteBytesArray(pkgs ...[]byte) (int, error) {
 
 	num := len(pkgs) - 1
 	for i := 0; i < num; i++ {
-		s.incWritePkgNum()
+		s.IncWritePkgNum()
 	}
 
 	return wlg, nil
@@ -563,7 +563,7 @@ func (s *session) run() {
 func (s *session) addTask(pkg interface{}) {
 	f := func() {
 		s.listener.OnMessage(s, pkg)
-		s.incReadPkgNum()
+		s.IncReadPkgNum()
 	}
 	if taskPool := s.EndPoint().GetTaskPool(); taskPool != nil {
 		taskPool.AddTaskAlways(f)
@@ -834,8 +834,8 @@ func (s *session) stop() {
 			// let read/Write timeout asap
 			now := time.Now()
 			if conn := s.Conn(); conn != nil {
-				conn.SetReadDeadline(now.Add(s.readTimeout()))
-				conn.SetWriteDeadline(now.Add(s.writeTimeout()))
+				conn.SetReadDeadline(now.Add(s.ReadTimeout()))
+				conn.SetWriteDeadline(now.Add(s.WriteTimeout()))
 			}
 			close(s.done)
 			c := s.GetAttribute(sessionClientKey)
@@ -859,7 +859,7 @@ func (s *session) gc() {
 
 	go func() {
 		if conn != nil {
-			conn.close(int(s.wait))
+			conn.CloseConn(int(s.wait))
 		}
 	}()
 }
@@ -933,59 +933,59 @@ func (s *session) RemoteAddr() string {
 	return ""
 }
 
-func (s *session) incReadPkgNum() {
+func (s *session) IncReadPkgNum() {
 	if s == nil {
 		return
 	}
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	if s.Connection != nil {
-		s.Connection.incReadPkgNum()
+		s.Connection.IncReadPkgNum()
 	}
 }
 
-func (s *session) incWritePkgNum() {
+func (s *session) IncWritePkgNum() {
 	if s == nil {
 		return
 	}
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	if s.Connection != nil {
-		s.Connection.incWritePkgNum()
+		s.Connection.IncWritePkgNum()
 	}
 }
 
-func (s *session) send(pkg interface{}) (int, error) {
+func (s *session) Send(pkg interface{}) (int, error) {
 	if s == nil {
 		return 0, nil
 	}
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	if s.Connection != nil {
-		return s.Connection.send(pkg)
+		return s.Connection.Send(pkg)
 	}
 	return 0, nil
 }
 
-func (s *session) readTimeout() time.Duration {
+func (s *session) ReadTimeout() time.Duration {
 	if s == nil {
 		return time.Duration(0)
 	}
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	if s.Connection != nil {
-		return s.Connection.readTimeout()
+		return s.Connection.ReadTimeout()
 	}
 	return time.Duration(0)
 }
 
-func (s *session) setSession(ss Session) {
+func (s *session) SetSession(ss Session) {
 	if s == nil {
 		return
 	}
 	s.lock.RLock()
 	if s.Connection != nil {
-		s.Connection.setSession(ss)
+		s.Connection.SetSession(ss)
 	}
 	s.lock.RUnlock()
 }


### PR DESCRIPTION
**What this PR does**:
Modify all the methods defined in getty.Connection to be exported with uppercase names.

**Which issue(s) this PR fixes**:
Fixes #100 

**Special notes for your reviewer**:
 I verified it using go workspace, and the gomock test worked well in seata-go.

**Does this PR introduce a user-facing change?**:
The methods involved are all used in getty's internal processes, and nothing has changed in terms of user usage.

```release-note
NONE
```