### PR TITLE
chore: unnecessary use of fmt.Sprintf

### DIFF
--- a/examples/echo/tcp-echo/client/app/config.go
+++ b/examples/echo/tcp-echo/client/app/config.go
@@ -100,7 +100,7 @@ func initConf() {
 	// configure
 	confFile = os.Getenv(APP_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("application configure file name is nil"))
+		panic("application configure file name is nil")
 		return // I know it is of no usage. Just Err Protection.
 	}
 	if path.Ext(confFile) != ".yml" {
@@ -159,14 +159,14 @@ func initConf() {
 	// log
 	confFile = os.Getenv(APP_LOG_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("log configure file name is nil"))
+		panic("log configure file name is nil")
 		return
 	}
 	if path.Ext(confFile) != ".xml" {
 		panic(fmt.Sprintf("log configure file name{%v} suffix must be .xml", confFile))
 		return
 	}
-	log.Info("config{%#v}", conf)
+	log.Infof("config{%#v}", conf)
 
 	return
 }

--- a/examples/echo/tcp-echo/server/app/config.go
+++ b/examples/echo/tcp-echo/server/app/config.go
@@ -87,7 +87,7 @@ func initConf() {
 	// configure
 	confFile = os.Getenv(APP_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("application configure file name is nil"))
+		panic("application configure file name is nil")
 		return // I know it is of no usage. Just Err Protection.
 	}
 	if path.Ext(confFile) != ".yml" {
@@ -141,7 +141,7 @@ func initConf() {
 	// log
 	confFile = os.Getenv(APP_LOG_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("log configure file name is nil"))
+		panic("log configure file name is nil")
 		return
 	}
 	if path.Ext(confFile) != ".xml" {

--- a/examples/echo/udp-echo/client/app/config.go
+++ b/examples/echo/udp-echo/client/app/config.go
@@ -95,7 +95,7 @@ func initConf() {
 	// configure
 	confFile = os.Getenv(APP_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("application configure file name is nil"))
+		panic("application configure file name is nil")
 		return // I know it is of no usage. Just Err Protection.
 	}
 	if path.Ext(confFile) != ".toml" {
@@ -140,7 +140,7 @@ func initConf() {
 	// log
 	confFile = os.Getenv(APP_LOG_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("log configure file name is nil"))
+		panic("log configure file name is nil")
 		return
 	}
 	if path.Ext(confFile) != ".xml" {

--- a/examples/echo/udp-echo/server/app/config.go
+++ b/examples/echo/udp-echo/server/app/config.go
@@ -82,7 +82,7 @@ func initConf() {
 	// configure
 	confFile = os.Getenv(APP_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("application configure file name is nil"))
+		panic("application configure file name is nil")
 		return // I know it is of no usage. Just Err Protection.
 	}
 	if path.Ext(confFile) != ".toml" {
@@ -123,13 +123,14 @@ func initConf() {
 	// log
 	confFile = os.Getenv(APP_LOG_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("log configure file name is nil"))
+		panic("log configure file name is nil")
 		return
 	}
 	if path.Ext(confFile) != ".xml" {
 		panic(fmt.Sprintf("log configure file name{%v} suffix must be .xml", confFile))
 		return
 	}
+
 	log.Infof("config{%#v}", conf)
 
 	return

--- a/examples/echo/ws-echo/client/app/config.go
+++ b/examples/echo/ws-echo/client/app/config.go
@@ -99,7 +99,7 @@ func initConf() {
 	// configure
 	confFile = os.Getenv(APP_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("application configure file name is nil"))
+		panic("application configure file name is nil")
 		return // I know it is of no usage. Just Err Protection.
 	}
 	if path.Ext(confFile) != ".toml" {
@@ -143,13 +143,14 @@ func initConf() {
 	// log
 	confFile = os.Getenv(APP_LOG_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("log configure file name is nil"))
+		panic("log configure file name is nil")
 		return
 	}
 	if path.Ext(confFile) != ".xml" {
 		panic(fmt.Sprintf("log configure file name{%v} suffix must be .xml", confFile))
 		return
 	}
+
 	log.Infof("config{%#v}", conf)
 
 	return

--- a/examples/echo/ws-echo/server/app/config.go
+++ b/examples/echo/ws-echo/server/app/config.go
@@ -88,7 +88,7 @@ func initConf() {
 	// configure
 	confFile = os.Getenv(APP_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("application configure file name is nil"))
+		panic("application configure file name is nil")
 		return // I know it is of no usage. Just Err Protection.
 	}
 	if path.Ext(confFile) != ".toml" {
@@ -136,7 +136,7 @@ func initConf() {
 	// log
 	confFile = os.Getenv(APP_LOG_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("log configure file name is nil"))
+		panic("log configure file name is nil")
 		return
 	}
 	if path.Ext(confFile) != ".xml" {

--- a/examples/echo/wss-echo/client/app/config.go
+++ b/examples/echo/wss-echo/client/app/config.go
@@ -103,7 +103,7 @@ func initConf() {
 	// configure
 	confFile = os.Getenv(APP_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("application configure file name is nil"))
+		panic("application configure file name is nil")
 		return // I know it is of no usage. Just Err Protection.
 	}
 	if path.Ext(confFile) != ".toml" {
@@ -147,7 +147,7 @@ func initConf() {
 	// log
 	confFile = os.Getenv(APP_LOG_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("log configure file name is nil"))
+		panic("log configure file name is nil")
 		return
 	}
 	if path.Ext(confFile) != ".xml" {

--- a/examples/echo/wss-echo/server/app/config.go
+++ b/examples/echo/wss-echo/server/app/config.go
@@ -94,7 +94,7 @@ func initConf() {
 	// configure
 	confFile = os.Getenv(APP_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("application configure file name is nil"))
+		panic("application configure file name is nil")
 		return // I know it is of no usage. Just Err Protection.
 	}
 	if path.Ext(confFile) != ".toml" {
@@ -142,7 +142,7 @@ func initConf() {
 	// log
 	confFile = os.Getenv(APP_LOG_CONF_FILE)
 	if confFile == "" {
-		panic(fmt.Sprintf("log configure file name is nil"))
+		panic("log configure file name is nil")
 		return
 	}
 	if path.Ext(confFile) != ".xml" {


### PR DESCRIPTION
**What this PR does**:
Remove unnecessary use of fmt.Sprintf.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Sync code from AlexStocks/getty.

**Does this PR introduce a user-facing change?**:
```release-note

```