### PR TITLE
fix: when session is closed, no need do OnMessage

### DIFF
--- a/session.go
+++ b/session.go
@@ -562,6 +562,11 @@ func (s *session) run() {
 
 func (s *session) addTask(pkg interface{}) {
 	f := func() {
+		// If the session is closed, there is no need to perform CPU-intensive operations.
+		if s.IsClosed() {
+			log.Errorf("[Id:%d, name=%s, endpoint=%s] Session is closed", s.ID(), s.name, s.EndPoint())
+			return
+		}
 		s.listener.OnMessage(s, pkg)
 		s.IncReadPkgNum()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
消息和请求时间结合看的话，应该请求很多。
初步感觉应该是很多消息同时过来导致一直在调用 encode或者decode 逻辑导致 cpu 飙升了。 可以在 conn close 的时候不做这些耗cpu的逻辑
![img_v3_028u_ab9dbba1-b919-4e88-979e-fd4dc7bde9cg](https://github.com/apache/dubbo-getty/assets/12541438/2b840141-cee3-4313-938f-aed90bc053c9)

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #107  

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```