### PR TITLE
fix issue116: limit the reconnect times or  duration

### DIFF
--- a/client.go
+++ b/client.go
@@ -56,11 +56,6 @@ var (
 	ignoreReconnectKey = "ignore-reconnect"
 )
 
-var (
-	num, max, times, interval int
-	maxDuraion                int64
-)
-
 type Client interface {
 	EndPoint
 }
@@ -428,6 +423,10 @@ func (c *client) RunEventLoop(newSession NewSessionCallback) {
 
 // a for-loop connect to make sure the connection pool is valid
 func (c *client) reConnect() {
+	var (
+		num, max, times, interval int
+		maxDuraion                int64
+	)
 	max = c.number
 	interval = c.reconnectInterval
 	if interval == 0 {
@@ -440,7 +439,7 @@ func (c *client) reConnect() {
 		}
 
 		num = c.sessionNum()
-		if max <= num || max < times { 
+		if max <= num || max < times {
 			//Exit when the number of connection pools is sufficient or the reconnection times exceeds the connections numbers.
 			break
 		}

--- a/client.go
+++ b/client.go
@@ -56,6 +56,10 @@ var (
 	ignoreReconnectKey = "ignore-reconnect"
 )
 
+var (
+	num, max, times, interval int
+	maxDuraion int64
+)
 type Client interface {
 	EndPoint
 }
@@ -423,8 +427,6 @@ func (c *client) RunEventLoop(newSession NewSessionCallback) {
 
 // a for-loop connect to make sure the connection pool is valid
 func (c *client) reConnect() {
-	var num, max, times, interval int
-	var maxDuraion int64
 	max = c.number
 	interval = c.reconnectInterval
 	if interval == 0 {
@@ -437,7 +439,8 @@ func (c *client) reConnect() {
 		}
 
 		num = c.sessionNum()
-		if max <= num || max < times { //Exit when the number of connection pools is sufficient or the reconnection times exceeds the connections numbers.
+		if max <= num || max < times { 
+			//Exit when the number of connection pools is sufficient or the reconnection times exceeds the connections numbers.
 			break
 		}
 		c.connect()

--- a/client.go
+++ b/client.go
@@ -28,14 +28,14 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+)
 
-	gxbytes "github.com/dubbogo/gost/bytes"
-
-	gxnet "github.com/dubbogo/gost/net"
-
+import (
+	"github.com/dubbogo/gost/bytes"
+	"github.com/dubbogo/gost/net"
 	gxsync "github.com/dubbogo/gost/sync"
-
 	gxtime "github.com/dubbogo/gost/time"
+
 	"github.com/gorilla/websocket"
 
 	perrors "github.com/pkg/errors"

--- a/client.go
+++ b/client.go
@@ -58,8 +58,9 @@ var (
 
 var (
 	num, max, times, interval int
-	maxDuraion int64
+	maxDuraion                int64
 )
+
 type Client interface {
 	EndPoint
 }

--- a/client.go
+++ b/client.go
@@ -425,7 +425,7 @@ func (c *client) RunEventLoop(newSession NewSessionCallback) {
 func (c *client) reConnect() {
 	var (
 		num, max, times, interval int
-		maxDuraion                int64
+		maxDuration               int64
 	)
 	max = c.number
 	interval = c.reconnectInterval
@@ -446,11 +446,11 @@ func (c *client) reConnect() {
 		c.connect()
 		times++
 		if times > maxTimes {
-			maxDuraion = int64(maxTimes) * int64(interval)
+			maxDuration = int64(maxTimes) * int64(interval)
 		} else {
-			maxDuraion = int64(times) * int64(interval)
+			maxDuration = int64(times) * int64(interval)
 		}
-		<-gxtime.After(time.Duration(maxDuraion))
+		<-gxtime.After(time.Duration(maxDuration))
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -27,12 +27,13 @@ import (
 	"runtime"
 	"sync"
 	"time"
+)
 
+import (
 	gxbytes "github.com/dubbogo/gost/bytes"
-
 	gxcontext "github.com/dubbogo/gost/context"
-
 	gxtime "github.com/dubbogo/gost/time"
+
 	"github.com/gorilla/websocket"
 
 	perrors "github.com/pkg/errors"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
 


1.客户端在read EOF时，停止重连维护连接池的行为
2.reconnect增加最大次数，当重连次数超过设定的连接数时，退出。
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #116

**Special notes for your reviewer**:
1.session增加了新的attribute（ignoreReconnectKey），用于标识是否重连
2.最大重连次数设定为用户设定的连接数
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```