### PR TITLE
fix: closing websocket connection returns invalid status code

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 import (
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -351,6 +352,26 @@ func TestNewWSClient(t *testing.T) {
 	assert.Equal(t, beforeWritePkgNum, conn.writePkgNum)
 	err = conn.writePing()
 	assert.Nil(t, err)
+
+	done := make(chan int)
+	conn.conn.SetCloseHandler(func(code int, text string) error {
+		defer func() {
+			done <- code
+			close(done)
+		}()
+		message := websocket.FormatCloseMessage(code, "")
+		conn.conn.WriteControl(websocket.CloseMessage, message, time.Now().Add(1e9))
+		return nil
+	})
+	serverSession := serverMsgHandler.array[0]
+	serverSession.Close()
+	select {
+	case code := <-done:
+		assert.True(t, code == websocket.CloseNormalClosure)
+	case <-time.After(5e9):
+		assert.True(t, false)
+	}
+	assert.True(t, serverSession.IsClosed())
 
 	ss.SetReader(nil)
 	assert.Nil(t, ss.(*session).reader)

--- a/connection.go
+++ b/connection.go
@@ -628,7 +628,7 @@ func (w *gettyWSConn) writePong(message []byte) error {
 // close websocket connection
 func (w *gettyWSConn) CloseConn(waitSec int) {
 	w.updateWriteDeadline()
-	w.conn.WriteMessage(websocket.CloseMessage, []byte("bye-bye!!!"))
+	w.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "bye-bye!!!"))
 	conn := w.conn.UnderlyingConn()
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		tcpConn.SetLinger(waitSec)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**: same as https://github.com/AlexStocks/getty/pull/74

**Which issue(s) this PR fixes**:   same as https://github.com/AlexStocks/getty/issues/73
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```