### PR TITLE
Improvement: rename the variables in TCP reconnect function and some default constants.

### DIFF
--- a/client.go
+++ b/client.go
@@ -42,10 +42,10 @@ import (
 )
 
 const (
-	reconnectInterval = 3e8 // 300ms
-	connectInterval   = 5e8 // 500ms
-	connectTimeout    = 3e9
-	maxTimes          = 10
+	defaultReconnectInterval    = 3e8 // 300ms
+	connectInterval             = 5e8 // 500ms
+	connectTimeout              = 3e9
+	defaultMaxReconnectAttempts = 10
 )
 
 var (
@@ -424,13 +424,13 @@ func (c *client) RunEventLoop(newSession NewSessionCallback) {
 // a for-loop connect to make sure the connection pool is valid
 func (c *client) reConnect() {
 	var (
-		num, max, times, interval int
-		maxDuration               int64
+		sessionNum, maxReconnectAttempts, reconnectAttempts, reconnectInterval int
+		maxReconnectInterval                                                   int64
 	)
-	max = c.number
-	interval = c.reconnectInterval
-	if interval == 0 {
-		interval = reconnectInterval
+	maxReconnectAttempts = c.number
+	reconnectInterval = c.reconnectInterval
+	if reconnectInterval == 0 {
+		reconnectInterval = defaultReconnectInterval
 	}
 	for {
 		if c.IsClosed() {
@@ -438,19 +438,19 @@ func (c *client) reConnect() {
 			break
 		}
 
-		num = c.sessionNum()
-		if max <= num || max < times {
-			//Exit when the number of connection pools is sufficient or the reconnection times exceeds the connections numbers.
+		sessionNum = c.sessionNum()
+		if maxReconnectAttempts <= sessionNum || maxReconnectAttempts < reconnectAttempts {
+			//exit reconnect when the number of connection pools is sufficient or the current reconnection attempts exceeds the max reconnection attempts.
 			break
 		}
 		c.connect()
-		times++
-		if times > maxTimes {
-			maxDuration = int64(maxTimes) * int64(interval)
+		reconnectAttempts++
+		if reconnectAttempts > defaultMaxReconnectAttempts {
+			maxReconnectInterval = int64(defaultMaxReconnectAttempts) * int64(reconnectInterval)
 		} else {
-			maxDuration = int64(times) * int64(interval)
+			maxReconnectInterval = int64(reconnectAttempts) * int64(reconnectInterval)
 		}
-		<-gxtime.After(time.Duration(maxDuration))
+		<-gxtime.After(time.Duration(maxReconnectInterval))
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

**rename the variables in TCP reconnect function and some default constants.**

1.rename constant 'reconnectInterval' to defaultReconnectInterval and 'maxTimes' to defaultMaxReconnectAttempts, indicates that these two constants are the default settings.

2.rename vars in reConnect():
- num->sessionNum,indicates the number of current sessions.
- max->maxReconnectAttempts,indicates the maximum attempt times of reconnections.
- times->reconnectAttempts, indicates the current number of reconnect attempts.
- interval->reconnectInterval,indicates the interval between each reconnection.
- maxDuration->maxReconnectInterval, indicates the max interval between each reconnection.

**Which issue(s) this PR fixes**:
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```