### PR TITLE
fix modernize fmt flag

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -28,7 +28,7 @@ jobs:
       # If you want to matrix build , you can append the following list.
       matrix:
         go_version:
-          - '1.24'
+          - '1.23'
         os:
           - ubuntu-latest
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -28,7 +28,7 @@ jobs:
       # If you want to matrix build , you can append the following list.
       matrix:
         go_version:
-          - '1.23'
+          - '1.24'
         os:
           - ubuntu-latest
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test: clean
 
 fmt: install-imports-formatter
 	# replace interface{} with any
-	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -any -fix -test ./...
+	go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@v0.38.0 -any -fix -test ./...
 	go fmt ./... && GOROOT=$(shell go env GOROOT) imports-formatter
 
 # Clean test generate files

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test: clean
 
 fmt: install-imports-formatter
 	# replace interface{} with any
-	go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@v0.38.0 -any -fix -test ./...
+	GOTOOLCHAIN=go1.24.0 go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@v0.38.0 -any -fix -test ./...
 	go fmt ./... && GOROOT=$(shell go env GOROOT) imports-formatter
 
 # Clean test generate files

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test: clean
 
 fmt: install-imports-formatter
 	# replace interface{} with any
-	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -category=efaceany -fix -test ./...
+	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -any -fix -test ./...
 	go fmt ./... && GOROOT=$(shell go env GOROOT) imports-formatter
 
 # Clean test generate files


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

Updates the `fmt` target in `Makefile` to use the current `modernize` CLI flag `-any` instead of the removed `-category=efaceany` flag.

This fixes the GitHub Actions `Check Code Format` step failure caused by `modernize@latest` no longer supporting `-category`.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #134

**Special notes for your reviewer**:

Local validation:

```bash
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -any -fix -test ./...
go fmt ./...
imports-formatter
go test ./... -coverprofile=coverage.txt -covermode=atomic
go vet ./...
golangci-lint run ./... --timeout=10m
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```