### PR TITLE
Fix  wss event loop panics on normal server shutdown/error return paths

### DIFF
--- a/server.go
+++ b/server.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -420,9 +421,27 @@ func (s *server) runWSEventLoop(newSession NewSessionCallback) {
 		s.lock.Unlock()
 		err = server.Serve(s.streamListener)
 		if err != nil {
-			log.Errorf("http.server.Serve(addr{%s}) = err:%+v", s.addr, perrors.WithStack(err))
+			if isHTTPServeCloseError(err) {
+				s.logHTTPServeClose(err)
+			} else {
+				s.logHTTPServeError(err)
+			}
 		}
 	}()
+}
+
+func (s *server) logHTTPServeClose(err error) {
+	log.Infof("http.server.Serve(addr{%s}) closed: %v", s.addr, err)
+}
+
+func isHTTPServeCloseError(err error) bool {
+	return errors.Is(err, http.ErrServerClosed) ||
+		errors.Is(err, net.ErrClosed) ||
+		strings.Contains(err.Error(), "use of closed network connection")
+}
+
+func (s *server) logHTTPServeError(err error) {
+	log.Errorf("http.server.Serve(addr{%s}) = err:%+v", s.addr, perrors.WithStack(err))
 }
 
 // serve websocket client request
@@ -480,7 +499,11 @@ func (s *server) runWSSEventLoop(newSession NewSessionCallback) {
 		s.lock.Unlock()
 		err = server.Serve(tls.NewListener(s.streamListener, config))
 		if err != nil {
-			log.Errorf("http.server.Serve(addr{%s}) = err:%+v", s.addr, perrors.WithStack(err))
+			if isHTTPServeCloseError(err) {
+				s.logHTTPServeClose(err)
+				return
+			}
+			s.logHTTPServeError(err)
 			panic(err)
 		}
 	}()

--- a/server.go
+++ b/server.go
@@ -437,8 +437,7 @@ func (s *server) logHTTPServeClose(err error) {
 
 func isHTTPServeCloseError(err error) bool {
 	return errors.Is(err, http.ErrServerClosed) ||
-		errors.Is(err, net.ErrClosed) ||
-		strings.Contains(err.Error(), "use of closed network connection")
+		errors.Is(err, net.ErrClosed)
 }
 
 func (s *server) logHTTPServeError(err error) {

--- a/server_test.go
+++ b/server_test.go
@@ -21,9 +21,12 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -250,6 +253,76 @@ func TestWSSServerCloseDoesNotPanic(t *testing.T) {
 	assert.True(t, srv.IsClosed())
 }
 
+func TestHTTPServeCloseErrorClassification(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "http server closed",
+			err:  http.ErrServerClosed,
+			want: true,
+		},
+		{
+			name: "wrapped net closed",
+			err:  fmt.Errorf("wrapped: %w", net.ErrClosed),
+			want: true,
+		},
+		{
+			name: "fatal error with closed listener text",
+			err:  errors.New("fatal listener failure after use of closed network connection marker"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isHTTPServeCloseError(tt.err))
+		})
+	}
+}
+
+func TestWSSEventLoopServeCloseErrorDoesNotPanic(t *testing.T) {
+	srv := newTestWSSServerWithListener(t, &serveErrorListener{
+		err: fmt.Errorf("listener closed: %w", net.ErrClosed),
+	})
+
+	srv.runWSSEventLoop(func(Session) error {
+		return nil
+	})
+	waitUntilHTTPServerReady(t, srv)
+	waitUntilServerLoopDone(t, srv)
+}
+
+func TestWSSEventLoopUnexpectedServeErrorPanics(t *testing.T) {
+	if os.Getenv("GETTY_WSS_FATAL_SERVE_ERROR") == "1" {
+		SetLogger(stderrTestLogger{})
+		srv := newTestWSSServerWithListener(t, &serveErrorListener{
+			err: errors.New("fatal listener failure after use of closed network connection marker"),
+		})
+
+		srv.runWSSEventLoop(func(Session) error {
+			return nil
+		})
+		srv.wg.Wait()
+		t.Fatal("expected WSS Serve error to panic")
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWSSEventLoopUnexpectedServeErrorPanics$")
+	cmd.Env = append(os.Environ(), "GETTY_WSS_FATAL_SERVE_ERROR=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected child process to fail from WSS Serve panic, got success:\n%s", output)
+	}
+	if !strings.Contains(string(output), "http.server.Serve") {
+		t.Fatalf("expected child process output to include WSS Serve error log, got:\n%s", output)
+	}
+	if !strings.Contains(string(output), "panic: fatal listener failure after use of closed network connection marker") {
+		t.Fatalf("expected child process output to include WSS Serve panic, got:\n%s", output)
+	}
+}
+
 type hijackResponseWriter struct {
 	header http.Header
 	conn   *selfConnectConn
@@ -311,6 +384,41 @@ func (c *selfConnectConn) SetWriteDeadline(time.Time) error {
 	return nil
 }
 
+type serveErrorListener struct {
+	err error
+}
+
+func (l *serveErrorListener) Accept() (net.Conn, error) {
+	return nil, l.err
+}
+
+func (l *serveErrorListener) Close() error {
+	return nil
+}
+
+func (l *serveErrorListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0}
+}
+
+func newTestWSSServerWithListener(t *testing.T, listener net.Listener) *server {
+	t.Helper()
+
+	certFile := filepath.Join(t.TempDir(), "server.crt")
+	keyFile := filepath.Join(t.TempDir(), "server.key")
+	assert.NoError(t, DownloadFile(certFile, WssServerCRT))
+	assert.NoError(t, DownloadFile(keyFile, WssServerKEY))
+
+	srv := NewWSSServer(
+		WithLocalAddress(listener.Addr().String()),
+		WithWebsocketServerPath("/hello"),
+		WithWebsocketServerCert(certFile),
+		WithWebsocketServerPrivateKey(keyFile),
+	).(*server)
+	srv.streamListener = listener
+
+	return srv
+}
+
 func waitUntilHTTPServerReady(t *testing.T, server *server) {
 	t.Helper()
 
@@ -333,3 +441,32 @@ func waitUntilHTTPServerReady(t *testing.T, server *server) {
 		}
 	}
 }
+
+func waitUntilServerLoopDone(t *testing.T, server *server) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		server.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for server event loop to exit")
+	}
+}
+
+type stderrTestLogger struct{}
+
+func (stderrTestLogger) Info(args ...any)     {}
+func (stderrTestLogger) Warn(args ...any)     {}
+func (stderrTestLogger) Error(args ...any)    {}
+func (stderrTestLogger) Debug(args ...any)    {}
+func (stderrTestLogger) Infof(string, ...any) {}
+func (stderrTestLogger) Warnf(string, ...any) {}
+func (stderrTestLogger) Errorf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+}
+func (stderrTestLogger) Debugf(string, ...any) {}

--- a/server_test.go
+++ b/server_test.go
@@ -183,3 +183,50 @@ func TestServer(t *testing.T) {
 	addr = "127.0.0.9999"
 	testTCPTlsServer(t, addr)
 }
+
+func TestWSSServerCloseDoesNotPanic(t *testing.T) {
+	certFile := filepath.Join(t.TempDir(), "server.crt")
+	keyFile := filepath.Join(t.TempDir(), "server.key")
+	assert.NoError(t, DownloadFile(certFile, WssServerCRT))
+	assert.NoError(t, DownloadFile(keyFile, WssServerKEY))
+
+	srv := NewWSSServer(
+		WithLocalAddress("127.0.0.1:0"),
+		WithWebsocketServerPath("/hello"),
+		WithWebsocketServerCert(certFile),
+		WithWebsocketServerPrivateKey(keyFile),
+	)
+	defer srv.Close()
+
+	var serverMsgHandler MessageHandler
+	srv.RunEventLoop(func(session Session) error {
+		return newSessionCallback(session, &serverMsgHandler)
+	})
+
+	waitUntilHTTPServerReady(t, srv.(*server))
+	srv.Close()
+	assert.True(t, srv.IsClosed())
+}
+
+func waitUntilHTTPServerReady(t *testing.T, server *server) {
+	t.Helper()
+
+	timeout := time.After(3 * time.Second)
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+
+	for {
+		server.lock.Lock()
+		ready := server.server != nil
+		server.lock.Unlock()
+		if ready {
+			return
+		}
+
+		select {
+		case <-timeout:
+			t.Fatal("timeout waiting for http server to start")
+		case <-tick.C:
+		}
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -192,9 +192,9 @@ func TestServer(t *testing.T) {
 }
 
 func TestWSServeWSRequestClosesSelfConnectConn(t *testing.T) {
-	srv := newServer(WS_SERVER)
+	server := newServer(WS_SERVER)
 	newSessionCalled := false
-	handler := newWSHandler(srv, func(Session) error {
+	handler := newWSHandler(server, func(Session) error {
 		newSessionCalled = true
 		return errors.New("self-connect request should not create session")
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:


This PR handles expected HTTP server shutdown errors in the WS/WSS event loops.

For WSS servers, normal shutdown or listener close errors are now treated as expected close paths instead of causing a panic. Unexpected WSS `Serve` errors still keep the original behavior: they are logged and then panic.

It also adds a regression test to verify that closing a WSS server does not panic during normal shutdown.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #132 

**Special notes for your reviewer**:


The WSS panic behavior is preserved for unexpected `Serve` failures. This PR only excludes expected shutdown errors such as `http.ErrServerClosed`, `net.ErrClosed`, and closed listener errors.

Validated with:

```bash
go test ./...
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
WSS server shutdown no longer panics when the underlying HTTP server or listener is closed normally.
```