### PR TITLE
udpReadBufferLenfunc and remove dead branch

### DIFF
--- a/session.go
+++ b/session.go
@@ -721,6 +721,18 @@ func (s *session) handleTCPPackage() error {
 	return perrors.WithStack(err)
 }
 
+func udpReadBufferLen(maxMsgLen int32) int {
+	maxBufLen := maxReadBufLen
+	if maxMsgLen > 0 {
+		maxMsgLen := int(maxMsgLen)
+		maxBufLen = maxMsgLen + maxReadBufLen
+		if maxMsgLen<<1 < maxBufLen {
+			maxBufLen = maxMsgLen << 1
+		}
+	}
+	return maxBufLen
+}
+
 // get package from udp packet
 func (s *session) handleUDPPackage() error {
 	var (
@@ -738,10 +750,7 @@ func (s *session) handleUDPPackage() error {
 	)
 
 	conn = s.Connection.(*gettyUDPConn)
-	maxBufLen = int(s.maxMsgLen + maxReadBufLen)
-	if int(s.maxMsgLen<<1) < bufLen {
-		maxBufLen = int(s.maxMsgLen << 1)
-	}
+	maxBufLen = udpReadBufferLen(s.maxMsgLen)
 	bufp = gxbytes.AcquireBytes(maxBufLen)
 	defer gxbytes.ReleaseBytes(bufp)
 	buf = *bufp

--- a/session.go
+++ b/session.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"runtime"
 	"sync"
@@ -721,13 +722,13 @@ func (s *session) handleTCPPackage() error {
 	return perrors.WithStack(err)
 }
 
-func udpReadBufferLen(maxMsgLen int32) int {
-	maxBufLen := maxReadBufLen
+func udpReadBufferLen(maxMsgLen int32) int64 {
+	maxBufLen := int64(maxReadBufLen)
 	if maxMsgLen > 0 {
-		maxMsgLen := int(maxMsgLen)
-		maxBufLen = maxMsgLen + maxReadBufLen
-		if maxMsgLen<<1 < maxBufLen {
-			maxBufLen = maxMsgLen << 1
+		msgLen := int64(maxMsgLen)
+		maxBufLen = msgLen + maxReadBufLen
+		if msgLen<<1 < maxBufLen {
+			maxBufLen = msgLen << 1
 		}
 	}
 	return maxBufLen
@@ -741,7 +742,7 @@ func (s *session) handleUDPPackage() error {
 		netError  net.Error
 		conn      *gettyUDPConn
 		bufLen    int
-		maxBufLen int
+		maxBufLen int64
 		bufp      *[]byte
 		buf       []byte
 		addr      *net.UDPAddr
@@ -751,7 +752,10 @@ func (s *session) handleUDPPackage() error {
 
 	conn = s.Connection.(*gettyUDPConn)
 	maxBufLen = udpReadBufferLen(s.maxMsgLen)
-	bufp = gxbytes.AcquireBytes(maxBufLen)
+	if maxBufLen > int64(math.MaxInt) {
+		return perrors.Errorf("udp read buffer length %d exceeds max int %d", maxBufLen, math.MaxInt)
+	}
+	bufp = gxbytes.AcquireBytes(int(maxBufLen))
 	defer gxbytes.ReleaseBytes(bufp)
 	buf = *bufp
 	for !s.IsClosed() {

--- a/session_test.go
+++ b/session_test.go
@@ -32,6 +32,48 @@ func (errorReader) Read(Session, []byte) (any, int, error) {
 	return nil, 0, errTestReadFailure
 }
 
+func TestUDPReadBufferLen(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxMsgLen int32
+		want      int
+	}{
+		{
+			name:      "negative max message length uses default read buffer",
+			maxMsgLen: -1,
+			want:      maxReadBufLen,
+		},
+		{
+			name:      "zero max message length uses default read buffer",
+			maxMsgLen: 0,
+			want:      maxReadBufLen,
+		},
+		{
+			name:      "small max message length caps buffer at twice max message length",
+			maxMsgLen: 1,
+			want:      2,
+		},
+		{
+			name:      "default max message length allows one extra read buffer",
+			maxMsgLen: maxReadBufLen,
+			want:      maxReadBufLen * 2,
+		},
+		{
+			name:      "larger max message length adds one read buffer",
+			maxMsgLen: maxReadBufLen * 2,
+			want:      maxReadBufLen * 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := udpReadBufferLen(tt.maxMsgLen); got != tt.want {
+				t.Fatalf("udpReadBufferLen(%d) = %d, want %d", tt.maxMsgLen, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHandlePackageWithNilListenerDoesNotPanicOnError(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/session_test.go
+++ b/session_test.go
@@ -19,6 +19,7 @@ package getty
 
 import (
 	"errors"
+	"math"
 	"net"
 	"testing"
 	"time"
@@ -62,6 +63,11 @@ func TestUDPReadBufferLen(t *testing.T) {
 			name:      "larger max message length adds one read buffer",
 			maxMsgLen: maxReadBufLen * 2,
 			want:      int64(maxReadBufLen * 3),
+		},
+		{
+			name:      "large max message length keeps 64-bit arithmetic",
+			maxMsgLen: math.MaxInt32,
+			want:      int64(math.MaxInt32) + maxReadBufLen,
 		},
 	}
 

--- a/session_test.go
+++ b/session_test.go
@@ -36,17 +36,17 @@ func TestUDPReadBufferLen(t *testing.T) {
 	tests := []struct {
 		name      string
 		maxMsgLen int32
-		want      int
+		want      int64
 	}{
 		{
 			name:      "negative max message length uses default read buffer",
 			maxMsgLen: -1,
-			want:      maxReadBufLen,
+			want:      int64(maxReadBufLen),
 		},
 		{
 			name:      "zero max message length uses default read buffer",
 			maxMsgLen: 0,
-			want:      maxReadBufLen,
+			want:      int64(maxReadBufLen),
 		},
 		{
 			name:      "small max message length caps buffer at twice max message length",
@@ -56,12 +56,12 @@ func TestUDPReadBufferLen(t *testing.T) {
 		{
 			name:      "default max message length allows one extra read buffer",
 			maxMsgLen: maxReadBufLen,
-			want:      maxReadBufLen * 2,
+			want:      int64(maxReadBufLen * 2),
 		},
 		{
 			name:      "larger max message length adds one read buffer",
 			maxMsgLen: maxReadBufLen * 2,
-			want:      maxReadBufLen * 3,
+			want:      int64(maxReadBufLen * 3),
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

  Fixes a UDP receive buffer sizing logic bug where the cap comparison used `bufLen` before it was populated by
  `conn.recv(buf)`, making the branch effectively dead. The buffer length calculation is now moved into
  `udpReadBufferLen`, and focused unit tests were added for the sizing rules.

**Which issue(s) this PR fixes**: #132 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Added table-driven tests for `udpReadBufferLen`, covering disabled/non-positive max message length, small message
  length capping, default sizing, and larger message lengths.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```