### PR TITLE
Fix client shutdown deadlock

### DIFF
--- a/client.go
+++ b/client.go
@@ -424,7 +424,28 @@ func (c *client) RunEventLoop(newSession NewSessionCallback) {
 	c.Lock()
 	c.newSession = newSession
 	c.Unlock()
-	c.reConnect()
+	<-c.runReconnect()
+}
+
+func (c *client) runReconnect() <-chan struct{} {
+	done := make(chan struct{})
+	c.Lock()
+	select {
+	case <-c.done:
+		c.Unlock()
+		close(done)
+		return done
+	default:
+		c.wg.Add(1)
+	}
+	c.Unlock()
+
+	go func() {
+		defer c.wg.Done()
+		defer close(done)
+		c.reConnect()
+	}()
+	return done
 }
 
 // a for-loop connect to make sure the connection pool is valid
@@ -456,28 +477,28 @@ func (c *client) reConnect() {
 		c.connect()
 		reconnectAttempts++
 		maxReconnectInterval = int64(math.Min(float64(reconnectAttempts), float64(maxBackOffTimes))) * int64(reconnectInterval)
-		<-gxtime.After(time.Duration(maxReconnectInterval))
+		select {
+		case <-c.done:
+			return
+		case <-gxtime.After(time.Duration(maxReconnectInterval)):
+		}
 	}
 }
 
 func (c *client) stop() {
-	select {
-	case <-c.done:
-		return
-	default:
-		c.Do(func() {
-			close(c.done)
-			c.Lock()
-			for s := range c.ssMap {
-				s.RemoveAttribute(sessionClientKey)
-				s.RemoveAttribute(ignoreReconnectKey)
-				s.Close()
-			}
-			c.ssMap = nil
+	c.Do(func() {
+		c.Lock()
+		close(c.done)
+		sessions := c.ssMap
+		c.ssMap = nil
+		c.Unlock()
 
-			c.Unlock()
-		})
-	}
+		for s := range sessions {
+			s.RemoveAttribute(sessionClientKey)
+			s.RemoveAttribute(ignoreReconnectKey)
+			s.Close()
+		}
+	})
 }
 
 func (c *client) IsClosed() bool {

--- a/client.go
+++ b/client.go
@@ -74,6 +74,9 @@ type client struct {
 	newSession NewSessionCallback
 	ssMap      map[Session]struct{}
 
+	reconnectDone    chan struct{}
+	reconnectPending bool
+
 	sync.Once
 	done chan struct{}
 }
@@ -428,11 +431,40 @@ func (c *client) runReconnect() <-chan struct{} {
 		return done
 	default:
 	}
+
+	if c.reconnectDone != nil {
+		c.reconnectPending = true
+		done = c.reconnectDone
+		c.Unlock()
+		return done
+	}
+
+	c.reconnectDone = done
+	c.reconnectPending = true
 	c.Unlock()
 
 	go func() {
 		defer close(done)
-		c.reConnect()
+		for {
+			c.Lock()
+			select {
+			case <-c.done:
+				c.reconnectDone = nil
+				c.reconnectPending = false
+				c.Unlock()
+				return
+			default:
+			}
+			if !c.reconnectPending {
+				c.reconnectDone = nil
+				c.Unlock()
+				return
+			}
+			c.reconnectPending = false
+			c.Unlock()
+
+			c.reConnect()
+		}
 	}()
 	return done
 }

--- a/client.go
+++ b/client.go
@@ -76,7 +76,6 @@ type client struct {
 
 	sync.Once
 	done chan struct{}
-	wg   sync.WaitGroup
 }
 
 func (c *client) init(opts ...ClientOption) {
@@ -428,12 +427,10 @@ func (c *client) runReconnect() <-chan struct{} {
 		close(done)
 		return done
 	default:
-		c.wg.Add(1)
 	}
 	c.Unlock()
 
 	go func() {
-		defer c.wg.Done()
 		defer close(done)
 		c.reConnect()
 	}()
@@ -510,5 +507,4 @@ func (c *client) IsClosed() bool {
 
 func (c *client) Close() {
 	c.stop()
-	c.wg.Wait()
 }

--- a/client_test.go
+++ b/client_test.go
@@ -47,16 +47,6 @@ func (h *PackageHandler) Write(ss Session, pkg any) ([]byte, error) {
 	return nil, nil
 }
 
-type failingPackageHandler struct{}
-
-func (h *failingPackageHandler) Read(ss Session, data []byte) (any, int, error) {
-	return nil, len(data), errors.New("test package read failure")
-}
-
-func (h *failingPackageHandler) Write(ss Session, pkg any) ([]byte, error) {
-	return nil, nil
-}
-
 type MessageHandler struct {
 	lock  sync.Mutex
 	array []Session
@@ -125,6 +115,7 @@ type countingTLSConfigBuilder struct {
 	calls   atomic.Int32
 	entered chan struct{}
 	release <-chan struct{}
+	exited  chan struct{}
 }
 
 func (b *countingTLSConfigBuilder) BuildTlsConfig() (*tls.Config, error) {
@@ -137,6 +128,12 @@ func (b *countingTLSConfigBuilder) BuildTlsConfig() (*tls.Config, error) {
 	}
 	if b.release != nil {
 		<-b.release
+	}
+	if b.exited != nil {
+		select {
+		case b.exited <- struct{}{}:
+		default:
+		}
 	}
 	return nil, errTestTLSConfig
 }
@@ -206,119 +203,7 @@ func TestRunReconnectAfterCloseIsNoop(t *testing.T) {
 	assert.Equal(t, int32(0), builder.calls.Load())
 }
 
-func TestSessionReconnectIsTrackedByClose(t *testing.T) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	assert.Nil(t, err)
-	assert.NotNil(t, listener)
-	acceptDone := make(chan struct{})
-	go func() {
-		defer close(acceptDone)
-		for {
-			conn, err := listener.Accept()
-			if err != nil {
-				return
-			}
-			defer func() {
-				_ = conn.Close()
-			}()
-		}
-	}()
-	defer func() {
-		_ = listener.Close()
-		<-acceptDone
-	}()
-
-	releaseReconnect := make(chan struct{})
-	var releaseOnce sync.Once
-	release := func() {
-		releaseOnce.Do(func() {
-			close(releaseReconnect)
-		})
-	}
-	defer release()
-
-	clt := newClient(
-		TCP_CLIENT,
-		WithServerAddress(listener.Addr().String()),
-		WithConnectionNumber(1),
-		WithReconnectInterval(int(2*time.Second)),
-		WithReconnectAttempts(3),
-	)
-	reconnectStarted := make(chan struct{}, 1)
-	var msgHandler MessageHandler
-	clt.newSession = func(session Session) error {
-		if err := newSessionCallback(session, &msgHandler); err != nil {
-			return err
-		}
-		select {
-		case reconnectStarted <- struct{}{}:
-		default:
-		}
-		<-releaseReconnect
-		return nil
-	}
-
-	localConn, peerConn := net.Pipe()
-	defer func() {
-		_ = localConn.Close()
-		_ = peerConn.Close()
-	}()
-	ss := newTCPSession(localConn, clt).(*session)
-	ss.SetAttribute(sessionClientKey, clt)
-	ss.SetAttribute(ignoreReconnectKey, false)
-
-	sessionStopDone := make(chan struct{})
-	go func() {
-		ss.stop()
-		close(sessionStopDone)
-	}()
-	select {
-	case <-reconnectStarted:
-	case <-time.After(time.Second):
-		t.Fatal("session-triggered reconnect did not start")
-	}
-
-	closeDone := make(chan struct{})
-	go func() {
-		clt.Close()
-		close(closeDone)
-	}()
-	select {
-	case <-closeDone:
-		t.Fatal("Close returned while the session-triggered reconnect was still running")
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	release()
-	select {
-	case <-closeDone:
-	case <-time.After(time.Second):
-		t.Fatal("Close did not return after the session-triggered reconnect completed")
-	}
-	select {
-	case <-sessionStopDone:
-	case <-time.After(time.Second):
-		t.Fatal("session stop did not return")
-	}
-}
-
-func TestSessionErrorReconnectInterleavesWithClose(t *testing.T) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	assert.Nil(t, err)
-	assert.NotNil(t, listener)
-
-	clientConn, err := net.DialTimeout("tcp", listener.Addr().String(), time.Second)
-	assert.Nil(t, err)
-	assert.NotNil(t, clientConn)
-	serverConn, err := listener.Accept()
-	assert.Nil(t, err)
-	assert.NotNil(t, serverConn)
-	defer func() {
-		_ = listener.Close()
-		_ = clientConn.Close()
-		_ = serverConn.Close()
-	}()
-
+func TestSessionTriggeredReconnectDoesNotBlockClose(t *testing.T) {
 	releaseReconnect := make(chan struct{})
 	var releaseOnce sync.Once
 	release := func() {
@@ -331,23 +216,24 @@ func TestSessionErrorReconnectInterleavesWithClose(t *testing.T) {
 	builder := &countingTLSConfigBuilder{
 		entered: make(chan struct{}, 1),
 		release: releaseReconnect,
+		exited:  make(chan struct{}, 1),
 	}
 	clt := newFailingReconnectClient(builder, 2*time.Second, 3)
 
-	var msgHandler MessageHandler
-	ss := newTCPSession(clientConn, clt).(*session)
-	assert.Nil(t, newSessionCallback(ss, &msgHandler))
-	ss.SetPkgHandler(&failingPackageHandler{})
+	localConn, peerConn := net.Pipe()
+	defer func() {
+		_ = localConn.Close()
+		_ = peerConn.Close()
+	}()
+	ss := newTCPSession(localConn, clt).(*session)
 	ss.SetAttribute(sessionClientKey, clt)
 	ss.SetAttribute(ignoreReconnectKey, false)
 
-	ss.run()
-	_, err = serverConn.Write([]byte("x"))
-	assert.Nil(t, err)
+	ss.stop()
 	select {
 	case <-builder.entered:
 	case <-time.After(time.Second):
-		t.Fatal("session error did not trigger reconnect")
+		t.Fatal("session-triggered reconnect did not start")
 	}
 
 	closeDone := make(chan struct{})
@@ -357,15 +243,73 @@ func TestSessionErrorReconnectInterleavesWithClose(t *testing.T) {
 	}()
 	select {
 	case <-closeDone:
-		t.Fatal("Close returned while session error reconnect was still running")
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Close blocked on the session-triggered reconnect worker")
 	}
-
 	release()
 	select {
-	case <-closeDone:
+	case <-builder.exited:
 	case <-time.After(time.Second):
-		t.Fatal("Close did not return after session error reconnect completed")
+		t.Fatal("session-triggered reconnect did not leave the blocked point after release")
+	}
+}
+
+func TestNewSessionCallbackCloseDoesNotDeadlock(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	assert.NotNil(t, listener)
+	accepted := make(chan struct{}, 1)
+	acceptDone := make(chan struct{})
+	go func() {
+		defer close(acceptDone)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			select {
+			case accepted <- struct{}{}:
+			default:
+			}
+			_ = conn.Close()
+		}
+	}()
+	defer func() {
+		_ = listener.Close()
+		<-acceptDone
+	}()
+
+	clt := newClient(
+		TCP_CLIENT,
+		WithServerAddress(listener.Addr().String()),
+		WithConnectionNumber(1),
+		WithReconnectInterval(int(time.Millisecond)),
+		WithReconnectAttempts(1),
+	)
+	callbackEntered := make(chan struct{})
+	runDone := make(chan struct{})
+	go func() {
+		clt.RunEventLoop(func(Session) error {
+			close(callbackEntered)
+			clt.Close()
+			return errors.New("reject session and stop client")
+		})
+		close(runDone)
+	}()
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("listener did not accept the client connection")
+	}
+	select {
+	case <-callbackEntered:
+	case <-time.After(time.Second):
+		t.Fatal("NewSessionCallback did not run")
+	}
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("RunEventLoop did not return after Close from NewSessionCallback")
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -52,6 +52,18 @@ type MessageHandler struct {
 	array []Session
 }
 
+type sessionCloseMessageHandler struct {
+	MessageHandler
+	closed chan struct{}
+}
+
+func (h *sessionCloseMessageHandler) OnClose(session Session) {
+	select {
+	case h.closed <- struct{}{}:
+	default:
+	}
+}
+
 func (h *MessageHandler) SessionNumber() int {
 	h.lock.Lock()
 	connNum := len(h.array)
@@ -148,6 +160,209 @@ func newFailingReconnectClient(builder TlsConfigBuilder, interval time.Duration,
 		WithClientSslEnabled(true),
 		WithClientTlsConfigBuilder(builder),
 	)
+}
+
+func newBlockingReconnectClient(t *testing.T) (*client, *MessageHandler, <-chan struct{}, func(), *atomic.Int32) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	assert.NotNil(t, listener)
+
+	acceptedConns := make(chan net.Conn, 8)
+	acceptDone := make(chan struct{})
+	go func() {
+		defer close(acceptDone)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			select {
+			case acceptedConns <- conn:
+			default:
+				_ = conn.Close()
+			}
+		}
+	}()
+
+	clt := newClient(
+		TCP_CLIENT,
+		WithServerAddress(listener.Addr().String()),
+		WithConnectionNumber(1),
+		WithReconnectInterval(int(time.Millisecond)),
+		WithReconnectAttempts(2),
+	)
+	var (
+		callbacks       atomic.Int32
+		callbackEntered = make(chan struct{}, 1)
+		releaseCallback = make(chan struct{})
+		releaseOnce     sync.Once
+		msgHandler      sessionCloseMessageHandler
+	)
+	msgHandler.closed = make(chan struct{}, 1)
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseCallback)
+		})
+	}
+	clt.newSession = func(session Session) error {
+		callbacks.Add(1)
+		select {
+		case callbackEntered <- struct{}{}:
+		default:
+		}
+		<-releaseCallback
+		if err := newSessionCallback(session, &msgHandler.MessageHandler); err != nil {
+			return err
+		}
+		session.SetEventListener(&msgHandler)
+		return nil
+	}
+	t.Cleanup(func() {
+		release()
+		_ = listener.Close()
+		<-acceptDone
+		closedAcceptedConn := false
+		for {
+			select {
+			case conn := <-acceptedConns:
+				closedAcceptedConn = true
+				_ = conn.Close()
+			default:
+				if closedAcceptedConn {
+					select {
+					case <-msgHandler.closed:
+					case <-time.After(time.Second):
+					}
+				}
+				clt.Close()
+				return
+			}
+		}
+	})
+
+	return clt, &msgHandler.MessageHandler, callbackEntered, release, &callbacks
+}
+
+func TestTCPClientReconnectRunsSingleFlight(t *testing.T) {
+	clt, msgHandler, callbackEntered, release, callbacks := newBlockingReconnectClient(t)
+
+	firstDone := clt.runReconnect()
+	select {
+	case <-callbackEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first reconnect did not enter NewSessionCallback")
+	}
+
+	secondDone := clt.runReconnect()
+	if secondDone != firstDone {
+		t.Fatal("concurrent reconnect trigger did not share the active worker")
+	}
+	assert.Equal(t, int32(1), callbacks.Load())
+	select {
+	case <-callbackEntered:
+		t.Fatal("concurrent reconnect trigger entered a second NewSessionCallback")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("single-flight reconnect did not finish")
+	}
+
+	assert.Equal(t, int32(1), callbacks.Load())
+	assert.Equal(t, 1, msgHandler.SessionNumber())
+	assert.Equal(t, 1, clt.sessionNum())
+}
+
+func TestSessionTriggeredReconnectIsCoalesced(t *testing.T) {
+	clt, msgHandler, callbackEntered, release, callbacks := newBlockingReconnectClient(t)
+
+	firstDone := clt.runReconnect()
+	select {
+	case <-callbackEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first reconnect did not enter NewSessionCallback")
+	}
+
+	localConn, peerConn := net.Pipe()
+	defer func() {
+		_ = localConn.Close()
+		_ = peerConn.Close()
+	}()
+	ss := newTCPSession(localConn, clt).(*session)
+	ss.SetAttribute(sessionClientKey, clt)
+	ss.SetAttribute(ignoreReconnectKey, false)
+	ss.stop()
+
+	clt.Lock()
+	activeDone := clt.reconnectDone
+	pending := clt.reconnectPending
+	clt.Unlock()
+	if activeDone != firstDone {
+		t.Fatal("session-triggered reconnect did not share the active worker")
+	}
+	assert.True(t, pending)
+	assert.Equal(t, int32(1), callbacks.Load())
+	select {
+	case <-callbackEntered:
+		t.Fatal("session-triggered reconnect entered a second NewSessionCallback")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("coalesced reconnect did not finish")
+	}
+
+	assert.Equal(t, int32(1), callbacks.Load())
+	assert.Equal(t, 1, msgHandler.SessionNumber())
+	assert.Equal(t, 1, clt.sessionNum())
+}
+
+func TestReconnectTriggerDuringBackoffIsCoalesced(t *testing.T) {
+	builder := &countingTLSConfigBuilder{
+		entered: make(chan struct{}, 2),
+		exited:  make(chan struct{}, 2),
+	}
+	clt := newFailingReconnectClient(builder, 200*time.Millisecond, 2)
+	firstDone := clt.runReconnect()
+
+	select {
+	case <-builder.entered:
+	case <-time.After(time.Second):
+		t.Fatal("first reconnect attempt did not start")
+	}
+	select {
+	case <-builder.exited:
+	case <-time.After(time.Second):
+		t.Fatal("first reconnect attempt did not finish")
+	}
+
+	secondDone := clt.runReconnect()
+	if secondDone != firstDone {
+		t.Fatal("backoff trigger did not share the active reconnect worker")
+	}
+
+	select {
+	case <-builder.entered:
+		t.Fatal("backoff trigger started a second reconnect worker too early")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	assert.Equal(t, int32(1), builder.calls.Load())
+
+	clt.Close()
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("reconnect worker did not finish after Close")
+	}
 }
 
 func TestReconnectBackoffIsCancelledByClose(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -103,7 +103,9 @@ func TestSessionReconnectIsTrackedByClose(t *testing.T) {
 			if err != nil {
 				return
 			}
-			defer conn.Close()
+			defer func() {
+				_ = conn.Close()
+			}()
 		}
 	}()
 	defer func() {

--- a/client_test.go
+++ b/client_test.go
@@ -19,12 +19,14 @@ package getty
 
 import (
 	"bytes"
+	"crypto/tls"
 	"errors"
 	"net"
 	"net/http"
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -42,6 +44,16 @@ func (h *PackageHandler) Read(ss Session, data []byte) (any, int, error) {
 }
 
 func (h *PackageHandler) Write(ss Session, pkg any) ([]byte, error) {
+	return nil, nil
+}
+
+type failingPackageHandler struct{}
+
+func (h *failingPackageHandler) Read(ss Session, data []byte) (any, int, error) {
+	return nil, len(data), errors.New("test package read failure")
+}
+
+func (h *failingPackageHandler) Write(ss Session, pkg any) ([]byte, error) {
 	return nil, nil
 }
 
@@ -105,6 +117,93 @@ func newSessionCallback(session Session, handler *MessageHandler) error {
 	session.SetWaitTime(3e9)
 
 	return nil
+}
+
+var errTestTLSConfig = errors.New("test TLS config failure")
+
+type countingTLSConfigBuilder struct {
+	calls   atomic.Int32
+	entered chan struct{}
+	release <-chan struct{}
+}
+
+func (b *countingTLSConfigBuilder) BuildTlsConfig() (*tls.Config, error) {
+	b.calls.Add(1)
+	if b.entered != nil {
+		select {
+		case b.entered <- struct{}{}:
+		default:
+		}
+	}
+	if b.release != nil {
+		<-b.release
+	}
+	return nil, errTestTLSConfig
+}
+
+func newFailingReconnectClient(builder TlsConfigBuilder, interval time.Duration, attempts int) *client {
+	return newClient(
+		TCP_CLIENT,
+		WithServerAddress("127.0.0.1:1"),
+		WithConnectionNumber(1),
+		WithReconnectInterval(int(interval)),
+		WithReconnectAttempts(attempts),
+		WithClientSslEnabled(true),
+		WithClientTlsConfigBuilder(builder),
+	)
+}
+
+func TestReconnectBackoffIsCancelledByClose(t *testing.T) {
+	builder := &countingTLSConfigBuilder{entered: make(chan struct{}, 4)}
+	clt := newFailingReconnectClient(builder, 2*time.Second, 3)
+
+	eventLoopDone := make(chan struct{})
+	go func() {
+		clt.RunEventLoop(func(Session) error { return nil })
+		close(eventLoopDone)
+	}()
+	select {
+	case <-builder.entered:
+	case <-time.After(time.Second):
+		t.Fatal("first reconnect attempt did not start")
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	closeDone := make(chan struct{})
+	go func() {
+		clt.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+	case <-time.After(200 * time.Millisecond):
+		select {
+		case <-closeDone:
+		case <-time.After(3 * time.Second):
+			t.Fatal("Close did not return after the current backoff elapsed")
+		}
+		t.Fatal("Close did not cancel the reconnect backoff")
+	}
+	select {
+	case <-eventLoopDone:
+	case <-time.After(time.Second):
+		t.Fatal("RunEventLoop did not return after Close")
+	}
+}
+
+func TestRunReconnectAfterCloseIsNoop(t *testing.T) {
+	builder := &countingTLSConfigBuilder{entered: make(chan struct{}, 1)}
+	clt := newFailingReconnectClient(builder, time.Millisecond, 1)
+	clt.Close()
+
+	done := clt.runReconnect()
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("runReconnect did not return immediately after Close")
+	}
+	assert.Equal(t, int32(0), builder.calls.Load())
 }
 
 func TestSessionReconnectIsTrackedByClose(t *testing.T) {
@@ -200,6 +299,73 @@ func TestSessionReconnectIsTrackedByClose(t *testing.T) {
 	case <-sessionStopDone:
 	case <-time.After(time.Second):
 		t.Fatal("session stop did not return")
+	}
+}
+
+func TestSessionErrorReconnectInterleavesWithClose(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	assert.NotNil(t, listener)
+
+	clientConn, err := net.DialTimeout("tcp", listener.Addr().String(), time.Second)
+	assert.Nil(t, err)
+	assert.NotNil(t, clientConn)
+	serverConn, err := listener.Accept()
+	assert.Nil(t, err)
+	assert.NotNil(t, serverConn)
+	defer func() {
+		_ = listener.Close()
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	}()
+
+	releaseReconnect := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseReconnect)
+		})
+	}
+	defer release()
+
+	builder := &countingTLSConfigBuilder{
+		entered: make(chan struct{}, 1),
+		release: releaseReconnect,
+	}
+	clt := newFailingReconnectClient(builder, 2*time.Second, 3)
+
+	var msgHandler MessageHandler
+	ss := newTCPSession(clientConn, clt).(*session)
+	assert.Nil(t, newSessionCallback(ss, &msgHandler))
+	ss.SetPkgHandler(&failingPackageHandler{})
+	ss.SetAttribute(sessionClientKey, clt)
+	ss.SetAttribute(ignoreReconnectKey, false)
+
+	ss.run()
+	_, err = serverConn.Write([]byte("x"))
+	assert.Nil(t, err)
+	select {
+	case <-builder.entered:
+	case <-time.After(time.Second):
+		t.Fatal("session error did not trigger reconnect")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		clt.Close()
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+		t.Fatal("Close returned while session error reconnect was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return after session error reconnect completed")
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -91,6 +91,100 @@ func newSessionCallback(session Session, handler *MessageHandler) error {
 	return nil
 }
 
+func TestSessionReconnectIsTrackedByClose(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	assert.NotNil(t, listener)
+	acceptDone := make(chan struct{})
+	go func() {
+		defer close(acceptDone)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+		}
+	}()
+	defer func() {
+		_ = listener.Close()
+		<-acceptDone
+	}()
+
+	releaseReconnect := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseReconnect)
+		})
+	}
+	defer release()
+
+	clt := newClient(
+		TCP_CLIENT,
+		WithServerAddress(listener.Addr().String()),
+		WithConnectionNumber(1),
+		WithReconnectInterval(int(2*time.Second)),
+		WithReconnectAttempts(3),
+	)
+	reconnectStarted := make(chan struct{}, 1)
+	var msgHandler MessageHandler
+	clt.newSession = func(session Session) error {
+		if err := newSessionCallback(session, &msgHandler); err != nil {
+			return err
+		}
+		select {
+		case reconnectStarted <- struct{}{}:
+		default:
+		}
+		<-releaseReconnect
+		return nil
+	}
+
+	localConn, peerConn := net.Pipe()
+	defer func() {
+		_ = localConn.Close()
+		_ = peerConn.Close()
+	}()
+	ss := newTCPSession(localConn, clt).(*session)
+	ss.SetAttribute(sessionClientKey, clt)
+	ss.SetAttribute(ignoreReconnectKey, false)
+
+	sessionStopDone := make(chan struct{})
+	go func() {
+		ss.stop()
+		close(sessionStopDone)
+	}()
+	select {
+	case <-reconnectStarted:
+	case <-time.After(time.Second):
+		t.Fatal("session-triggered reconnect did not start")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		clt.Close()
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+		t.Fatal("Close returned while the session-triggered reconnect was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return after the session-triggered reconnect completed")
+	}
+	select {
+	case <-sessionStopDone:
+	case <-time.After(time.Second):
+		t.Fatal("session stop did not return")
+	}
+}
+
 func TestTCPClient(t *testing.T) {
 	listenLocalServer := func() (net.Listener, error) {
 		listener, err := net.Listen("tcp", ":0")

--- a/session.go
+++ b/session.go
@@ -856,7 +856,7 @@ func (s *session) stop() {
 			clt, cltFound := s.GetAttribute(sessionClientKey).(*client)
 			ignoreReconnect, flagFound := s.GetAttribute(ignoreReconnectKey).(bool)
 			if cltFound && flagFound && !ignoreReconnect {
-				clt.reConnect()
+				clt.runReconnect()
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:


Prevents client shutdown from deadlocking or hanging when session teardown can trigger reconnect logic.

This PR:
- closes client sessions outside the client map lock by snapshotting `ssMap` during shutdown
- introduces `runReconnect()` to start reconnect loops only while the client is open and track them with the client `WaitGroup`
- routes session-triggered reconnect through `runReconnect()` instead of synchronously calling `reConnect()`
- ensures reconnect backoff is cancelled by `Client.Close()`
- adds regression coverage for shutdown/reconnect interleavings, backoff cancellation, and no-op reconnect after close


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #132 

**Special notes for your reviewer**:

The branch has been merged with the latest `origin/master`

Additional tests cover:
- session error triggering reconnect while `Client.Close()` is running
- `Client.Close()` cancelling reconnect backoff
- `runReconnect()` becoming a no-op after client shutdown
- `Client.Close()` waiting for an in-flight session-triggered reconnect


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```